### PR TITLE
improved debug logging of squads and missions, reduce defence radius growth significantly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 replays/
 *.tgz
 *.rpl
+*.log
+

--- a/src/bot/logic/common/utils.ts
+++ b/src/bot/logic/common/utils.ts
@@ -1,0 +1,1 @@
+export type DebugLogger = (message: string, sayInGame?: boolean) => void;

--- a/src/bot/logic/mission/mission.ts
+++ b/src/bot/logic/mission/mission.ts
@@ -2,6 +2,7 @@ import { GameApi, PlayerData } from "@chronodivide/game-api";
 import { Squad } from "../squad/squad.js";
 import { GlobalThreat } from "../threat/threat.js";
 import { MatchAwareness } from "../awareness.js";
+import { DebugLogger } from "../common/utils.js";
 
 // AI starts Missions based on heuristics, which have one or more squads.
 // Missions can create squads (but squads will disband themselves).
@@ -11,7 +12,7 @@ export abstract class Mission<FailureReasons = undefined> {
 
     private onFinish: (reason: FailureReasons, squad: Squad | null) => void = () => {};
 
-    constructor(private uniqueName: string, private priority: number = 1) {}
+    constructor(private uniqueName: string, private priority: number, protected logger: DebugLogger) {}
 
     abstract onAiUpdate(gameApi: GameApi, playerData: PlayerData, matchAwareness: MatchAwareness): MissionAction;
 

--- a/src/bot/logic/mission/missionController.ts
+++ b/src/bot/logic/mission/missionController.ts
@@ -1,7 +1,6 @@
 // Meta-controller for forming and controlling squads.
 
 import { GameApi, PlayerData } from "@chronodivide/game-api";
-import { GlobalThreat } from "../threat/threat.js";
 import { Mission, MissionAction, MissionActionDisband, MissionActionRegisterSquad } from "./mission.js";
 import { SquadController } from "../squad/squadController.js";
 import { MatchAwareness } from "../awareness.js";
@@ -70,9 +69,9 @@ export class MissionController {
 
         // Create dynamic missions.
         this.missionFactories.forEach((missionFactory) => {
-            missionFactory.maybeCreateMissions(gameApi, playerData, matchAwareness, this);
+            missionFactory.maybeCreateMissions(gameApi, playerData, matchAwareness, this, this.logger);
             disbandedMissionsArray.forEach(({ reason, mission }) => {
-                missionFactory.onMissionFailed(gameApi, playerData, matchAwareness, mission, reason, this);
+                missionFactory.onMissionFailed(gameApi, playerData, matchAwareness, mission, reason, this, this.logger);
             });
         });
     }

--- a/src/bot/logic/mission/missionFactories.ts
+++ b/src/bot/logic/mission/missionFactories.ts
@@ -6,6 +6,7 @@ import { ScoutingMissionFactory } from "./missions/scoutingMission.js";
 import { AttackMissionFactory } from "./missions/attackMission.js";
 import { MissionController } from "./missionController.js";
 import { DefenceMissionFactory } from "./missions/defenceMission.js";
+import { DebugLogger } from "../common/utils.js";
 
 export interface MissionFactory {
     getName(): string;
@@ -23,6 +24,7 @@ export interface MissionFactory {
         playerData: PlayerData,
         matchAwareness: MatchAwareness,
         missionController: MissionController,
+        logger: DebugLogger
     ): void;
 
     /**
@@ -35,6 +37,7 @@ export interface MissionFactory {
         failedMission: Mission,
         failureReason: any,
         missionController: MissionController,
+        logger: DebugLogger
     ): void;
 }
 

--- a/src/bot/logic/mission/missions/attackMission.ts
+++ b/src/bot/logic/mission/missions/attackMission.ts
@@ -11,6 +11,7 @@ import { MissionController } from "../missionController.js";
 import { match } from "assert";
 import { RetreatMission } from "./retreatMission.js";
 import _ from "lodash";
+import { DebugLogger } from "../../common/utils.js";
 
 export enum AttackFailReason {
     NoTargets = 0,
@@ -31,8 +32,9 @@ export class AttackMission extends Mission<AttackFailReason> {
         private rallyArea: Point2D,
         private attackArea: Point2D,
         private radius: number,
+        logger: DebugLogger
     ) {
-        super(uniqueName, priority);
+        super(uniqueName, priority, logger);
     }
 
     onAiUpdate(gameApi: GameApi, playerData: PlayerData, matchAwareness: MatchAwareness): MissionAction {
@@ -104,6 +106,7 @@ export class AttackMissionFactory implements MissionFactory {
         playerData: PlayerData,
         matchAwareness: MatchAwareness,
         missionController: MissionController,
+        logger: DebugLogger
     ): void {
         if (!matchAwareness.shouldAttack()) {
             return;
@@ -125,7 +128,7 @@ export class AttackMissionFactory implements MissionFactory {
         const squadName = "globalAttack";
 
         const tryAttack = missionController.addMission(
-            new AttackMission(squadName, 100, matchAwareness.getMainRallyPoint(), attackArea, attackRadius).then(
+            new AttackMission(squadName, 100, matchAwareness.getMainRallyPoint(), attackArea, attackRadius, logger).then(
                 (reason, squad) => {
                     missionController.addMission(
                         new RetreatMission(
@@ -133,6 +136,7 @@ export class AttackMissionFactory implements MissionFactory {
                             100,
                             matchAwareness.getMainRallyPoint(),
                             squad?.getUnitIds() ?? [],
+                            logger,
                         ),
                     );
                 },

--- a/src/bot/logic/mission/missions/defenceMission.ts
+++ b/src/bot/logic/mission/missions/defenceMission.ts
@@ -6,6 +6,7 @@ import { MissionFactory } from "../missionFactories.js";
 import { Squad } from "../../squad/squad.js";
 import { CombatSquad } from "../../squad/behaviours/combatSquad.js";
 import { RetreatMission } from "./retreatMission.js";
+import { DebugLogger } from "../../common/utils.js";
 
 export enum DefenceFailReason {
     NoTargets,
@@ -22,8 +23,9 @@ export class DefenceMission extends Mission<DefenceFailReason> {
         priority: number,
         private defenceArea: Point2D,
         private radius: number,
+        logger: DebugLogger,
     ) {
-        super(uniqueName, priority);
+        super(uniqueName, priority, logger);
     }
 
     onAiUpdate(gameApi: GameApi, playerData: PlayerData, matchAwareness: MatchAwareness): MissionAction {
@@ -35,8 +37,15 @@ export class DefenceMission extends Mission<DefenceFailReason> {
             const foundTargets = matchAwareness.getHostilesNearPoint2d(this.defenceArea, this.radius);
 
             if (foundTargets.length === 0) {
+                this.logger(`(Defence Mission ${this.getUniqueName()}): No targets found, disbanding.`);
                 return disbandMission(DefenceFailReason.NoTargets);
             } else {
+                const targetUnit = gameApi.getUnitData(foundTargets[0].unitId);
+                this.logger(
+                    `(Defence Mission ${this.getUniqueName()}): Focused on target ${targetUnit?.name} (${
+                        foundTargets.length
+                    } found in area ${this.radius})`,
+                );
                 this.combatSquad?.setAttackArea({ x: foundTargets[0].x, y: foundTargets[0].y });
             }
         }
@@ -49,7 +58,7 @@ const DEFENCE_CHECK_TICKS = 30;
 // Starting radius around the player's base to trigger defense.
 const DEFENCE_STARTING_RADIUS = 10;
 // Every game tick, we increase the defendable area by this amount.
-const DEFENCE_RADIUS_INCREASE_PER_GAME_TICK = 0.005;
+const DEFENCE_RADIUS_INCREASE_PER_GAME_TICK = 0.001;
 
 export class DefenceMissionFactory implements MissionFactory {
     private lastDefenceCheckAt = 0;
@@ -65,6 +74,7 @@ export class DefenceMissionFactory implements MissionFactory {
         playerData: PlayerData,
         matchAwareness: MatchAwareness,
         missionController: MissionController,
+        logger: DebugLogger,
     ): void {
         if (gameApi.getCurrentTick() < this.lastDefenceCheckAt + DEFENCE_CHECK_TICKS) {
             return;
@@ -76,19 +86,29 @@ export class DefenceMissionFactory implements MissionFactory {
         const enemiesNearSpawn = matchAwareness.getHostilesNearPoint2d(playerData.startLocation, defendableRadius);
 
         if (enemiesNearSpawn.length > 0) {
+            logger(
+                `Starting defence mission, ${
+                    enemiesNearSpawn.length
+                } found in radius ${defendableRadius} (tick ${gameApi.getCurrentTick()})`,
+            );
             missionController.addMission(
-                new DefenceMission("globalDefence", 1000, playerData.startLocation, defendableRadius * 1.2).then(
-                    (reason, squad) => {
-                        missionController.addMission(
-                            new RetreatMission(
-                                "retreat-from-globalDefence" + gameApi.getCurrentTick(),
-                                100,
-                                matchAwareness.getMainRallyPoint(),
-                                squad?.getUnitIds() ?? [],
-                            ),
-                        );
-                    },
-                ),
+                new DefenceMission(
+                    "globalDefence",
+                    1000,
+                    playerData.startLocation,
+                    defendableRadius * 1.2,
+                    logger,
+                ).then((reason, squad) => {
+                    missionController.addMission(
+                        new RetreatMission(
+                            "retreat-from-globalDefence" + gameApi.getCurrentTick(),
+                            100,
+                            matchAwareness.getMainRallyPoint(),
+                            squad?.getUnitIds() ?? [],
+                            logger,
+                        ),
+                    );
+                }),
             );
         }
     }

--- a/src/bot/logic/mission/missions/expansionMission.ts
+++ b/src/bot/logic/mission/missions/expansionMission.ts
@@ -5,15 +5,16 @@ import { ExpansionSquad } from "../../squad/behaviours/expansionSquad.js";
 import { MissionFactory } from "../missionFactories.js";
 import { OneTimeMission } from "./oneTimeMission.js";
 import { MatchAwareness } from "../../awareness.js";
-import { AttackFailReason, AttackMission } from "./attackMission.js";
 import { MissionController } from "../missionController.js";
+import { DebugLogger } from "../../common/utils.js";
 
 /**
  * A mission that tries to create an MCV (if it doesn't exist) and deploy it somewhere it can be deployed.
  */
 export class ExpansionMission extends OneTimeMission {
-    constructor(uniqueName: string, priority: number, selectedMcv: number | null) {
-        super(uniqueName, priority, () => new ExpansionSquad(selectedMcv));
+    constructor(uniqueName: string, priority: number, selectedMcv: number | null, 
+        logger: DebugLogger) {
+        super(uniqueName, priority, () => new ExpansionSquad(selectedMcv), logger);
     }
 }
 
@@ -27,13 +28,14 @@ export class ExpansionMissionFactory implements MissionFactory {
         playerData: PlayerData,
         matchAwareness: MatchAwareness,
         missionController: MissionController,
+        logger: DebugLogger
     ): void {
         // At this point, only expand if we have a loose MCV.
         const mcvs = gameApi.getVisibleUnits(playerData.name, "self", (r) =>
             gameApi.getGeneralRules().baseUnit.includes(r.name)
         );
         mcvs.forEach((mcv) => {
-            missionController.addMission(new ExpansionMission("expand-with-" + mcv, 100, mcv));
+            missionController.addMission(new ExpansionMission("expand-with-" + mcv, 100, mcv, logger));
         });
     }
 

--- a/src/bot/logic/mission/missions/oneTimeMission.ts
+++ b/src/bot/logic/mission/missions/oneTimeMission.ts
@@ -6,6 +6,7 @@ import { Squad } from "../../squad/squad.js";
 import { MissionFactory } from "../missionFactories.js";
 import { SquadBehaviour } from "../../squad/squadBehaviour.js";
 import { MatchAwareness } from "../../awareness.js";
+import { DebugLogger } from "../../common/utils.js";
 
 /**
  * A mission that gets dispatched once, and once the squad decides to disband, the mission is disbanded.
@@ -13,8 +14,8 @@ import { MatchAwareness } from "../../awareness.js";
 export abstract class OneTimeMission<T = undefined> extends Mission<T> {
     private hadSquad = false;
 
-    constructor(uniqueName: string, priority: number, private behaviourFactory: () => SquadBehaviour) {
-        super(uniqueName, priority);
+    constructor(uniqueName: string, priority: number, private behaviourFactory: () => SquadBehaviour, logger: DebugLogger) {
+        super(uniqueName, priority, logger);
     }
 
     onAiUpdate(gameApi: GameApi, playerData: PlayerData, matchAwareness: MatchAwareness): MissionAction {

--- a/src/bot/logic/mission/missions/retreatMission.ts
+++ b/src/bot/logic/mission/missions/retreatMission.ts
@@ -1,9 +1,10 @@
 import { Point2D } from "@chronodivide/game-api";
 import { OneTimeMission } from "./oneTimeMission.js";
 import { RetreatSquad } from "../../squad/behaviours/retreatSquad.js";
+import { DebugLogger } from "../../common/utils.js";
 
 export class RetreatMission extends OneTimeMission {
-    constructor(uniqueName: string, priority: number, retreatToPoint: Point2D, unitIds: number[]) {
-        super(uniqueName, priority, () => new RetreatSquad(unitIds, retreatToPoint));
+    constructor(uniqueName: string, priority: number, retreatToPoint: Point2D, unitIds: number[], logger: DebugLogger) {
+        super(uniqueName, priority, () => new RetreatSquad(unitIds, retreatToPoint), logger);
     }
 }

--- a/src/bot/logic/mission/missions/scoutingMission.ts
+++ b/src/bot/logic/mission/missions/scoutingMission.ts
@@ -7,13 +7,15 @@ import { Mission } from "../mission.js";
 import { AttackMission } from "./attackMission.js";
 import { MissionController } from "../missionController.js";
 import { getUnseenStartingLocations } from "../../common/scout.js";
+import { DebugLogger } from "../../common/utils.js";
 
 /**
  * A mission that tries to scout around the map with a cheap, fast unit (usually attack dogs)
  */
 export class ScoutingMission extends OneTimeMission {
-    constructor(uniqueName: string, priority: number) {
-        super(uniqueName, priority, () => new ScoutingSquad());
+    constructor(uniqueName: string, priority: number, 
+        logger: DebugLogger) {
+        super(uniqueName, priority, () => new ScoutingSquad(), logger);
     }
 }
 
@@ -31,6 +33,7 @@ export class ScoutingMissionFactory implements MissionFactory {
         playerData: PlayerData,
         matchAwareness: MatchAwareness,
         missionController: MissionController,
+        logger: DebugLogger
     ): void {
         if (gameApi.getCurrentTick() < this.lastScoutAt + SCOUT_COOLDOWN_TICKS) {
             return;
@@ -39,7 +42,7 @@ export class ScoutingMissionFactory implements MissionFactory {
         if (candidatePoints.length === 0) {
             return;
         }
-        if (!missionController.addMission(new ScoutingMission("globalScout", 100))) {
+        if (!missionController.addMission(new ScoutingMission("globalScout", 100, logger))) {
             this.lastScoutAt = gameApi.getCurrentTick();
         }
     }
@@ -51,9 +54,10 @@ export class ScoutingMissionFactory implements MissionFactory {
         failedMission: Mission,
         failureReason: undefined,
         missionController: MissionController,
+        logger: DebugLogger
     ): void {
         if (failedMission instanceof AttackMission) {
-            missionController.addMission(new ScoutingMission("globalScout", 100));
+            missionController.addMission(new ScoutingMission("globalScout", 100, logger));
         }
     }
 }

--- a/src/bot/logic/squad/behaviours/combatSquad.ts
+++ b/src/bot/logic/squad/behaviours/combatSquad.ts
@@ -5,6 +5,7 @@ import { SquadAction, SquadBehaviour, grabCombatants, noop } from "../squadBehav
 import { MatchAwareness } from "../../awareness.js";
 import { getDistanceBetweenPoints } from "../../map/map.js";
 import { manageAttackMicro, manageMoveMicro } from "./common.js";
+import { DebugLogger } from "../../common/utils.js";
 
 const TARGET_UPDATE_INTERVAL_TICKS = 10;
 const GRAB_INTERVAL_TICKS = 10;
@@ -52,8 +53,9 @@ export class CombatSquad implements SquadBehaviour {
         playerData: PlayerData,
         squad: Squad,
         matchAwareness: MatchAwareness,
+        logger: DebugLogger,
     ): SquadAction {
-        if (!this.lastCommand || gameApi.getCurrentTick() > this.lastCommand + TARGET_UPDATE_INTERVAL_TICKS) {
+        if (squad.getUnitIds().length > 0 && (!this.lastCommand || gameApi.getCurrentTick() > this.lastCommand + TARGET_UPDATE_INTERVAL_TICKS)) {
             this.lastCommand = gameApi.getCurrentTick();
             const centerOfMass = squad.getCenterOfMass();
             const maxDistance = squad.getMaxDistanceToCenterOfMass();
@@ -81,6 +83,7 @@ export class CombatSquad implements SquadBehaviour {
                         manageMoveMicro(actionsApi, unit, centerOfMass);
                     });
                 } else {
+                    logger(`CombatSquad ${squad.getName()} switching back to attack mode (${maxDistance})`)
                     this.state = SquadState.Attacking;
                 }
             } else {
@@ -93,6 +96,7 @@ export class CombatSquad implements SquadBehaviour {
                     maxDistance > requiredGatherRadius
                 ) {
                     // Switch back to gather mode
+                    logger(`CombatSquad ${squad.getName()} switching back to gather (${maxDistance})`)
                     this.state = SquadState.Gathering;
                     return noop();
                 }

--- a/src/bot/logic/squad/squad.ts
+++ b/src/bot/logic/squad/squad.ts
@@ -5,6 +5,7 @@ import { SquadAction, SquadBehaviour, disband } from "./squadBehaviour.js";
 import { MatchAwareness } from "../awareness.js";
 import { getDistanceBetweenPoints } from "../map/map.js";
 import _ from "lodash";
+import { DebugLogger } from "../common/utils.js";
 
 export enum SquadLiveness {
     SquadDead,
@@ -76,6 +77,7 @@ export class Squad {
         actionsApi: ActionsApi,
         playerData: PlayerData,
         matchAwareness: MatchAwareness,
+        logger: DebugLogger
     ): SquadAction {
         this.updateLiveness(gameApi);
         const movableUnitTiles = this.unitIds
@@ -100,8 +102,7 @@ export class Squad {
         } else if (!this.mission) {
             return disband();
         }
-        let outcome = this.behaviour.onAiUpdate(gameApi, actionsApi, playerData, this, matchAwareness);
-        return outcome;
+        return this.behaviour.onAiUpdate(gameApi, actionsApi, playerData, this, matchAwareness, logger);
     }
     public getMission(): Mission | null {
         return this.mission;

--- a/src/bot/logic/squad/squadBehaviour.ts
+++ b/src/bot/logic/squad/squadBehaviour.ts
@@ -2,6 +2,7 @@ import { ActionsApi, GameApi, PlayerData, Point2D } from "@chronodivide/game-api
 import { GlobalThreat } from "../threat/threat.js";
 import { Squad } from "./squad.js";
 import { MatchAwareness } from "../awareness.js";
+import { DebugLogger } from "../common/utils.js";
 
 export type SquadActionNoop = {
     type: "noop";
@@ -56,6 +57,7 @@ export interface SquadBehaviour {
         actionsApi: ActionsApi,
         playerData: PlayerData,
         squad: Squad,
-        matchAwareness: MatchAwareness
+        matchAwareness: MatchAwareness,
+        logger: DebugLogger
     ): SquadAction;
 }


### PR DESCRIPTION
Background: the bot tries to defend a radius around its startLocation that grows by a small amount every tick.

The improved debugging made me realise that the bot was constantly trying to defend an area that quickly grew to encompass the enemy base. This is why it was sending units one at a time to the enemy base, even when it would not make sense to attack the enemy based on the assessed strength.

By making this small change, the bot now correctly gathers a small army at its mainRallyPoint as intended, so attack missions are more sensible