### PR TITLE
implement engineer capturing of tech derricks

### DIFF
--- a/src/bot/logic/building/ArtilleryUnit.ts
+++ b/src/bot/logic/building/ArtilleryUnit.ts
@@ -1,6 +1,6 @@
 import { GameApi, PlayerData, TechnoRules } from "@chronodivide/game-api";
 import { GlobalThreat } from "../threat/threat.js";
-import { AiBuildingRules, getDefaultPlacementLocation, numBuildingsOwnedOfType } from "./building.js";
+import { AiBuildingRules, getDefaultPlacementLocation, numBuildingsOwnedOfType } from "./buildingRules.js";
 
 export class ArtilleryUnit implements AiBuildingRules {
     constructor(private basePriority: number, private baseAmount: number) {}

--- a/src/bot/logic/building/antiGroundStaticDefence.ts
+++ b/src/bot/logic/building/antiGroundStaticDefence.ts
@@ -1,7 +1,7 @@
 import { GameApi, PlayerData, Point2D, TechnoRules } from "@chronodivide/game-api";
 import { getPointTowardsOtherPoint } from "../map/map.js";
 import { GlobalThreat } from "../threat/threat.js";
-import { AiBuildingRules, getDefaultPlacementLocation, numBuildingsOwnedOfType } from "./building.js";
+import { AiBuildingRules, getDefaultPlacementLocation, numBuildingsOwnedOfType } from "./buildingRules.js";
 
 export class AntiGroundStaticDefence implements AiBuildingRules {
     constructor(private basePriority: number, private baseAmount: number, private strength: number) {}

--- a/src/bot/logic/building/basicAirUnit.ts
+++ b/src/bot/logic/building/basicAirUnit.ts
@@ -1,6 +1,6 @@
 import { GameApi, PlayerData, TechnoRules } from "@chronodivide/game-api";
 import { GlobalThreat } from "../threat/threat.js";
-import { AiBuildingRules, getDefaultPlacementLocation, numBuildingsOwnedOfType } from "./building.js";
+import { AiBuildingRules, getDefaultPlacementLocation, numBuildingsOwnedOfType } from "./buildingRules.js";
 
 export class BasicAirUnit implements AiBuildingRules {
     constructor(

--- a/src/bot/logic/building/basicBuilding.ts
+++ b/src/bot/logic/building/basicBuilding.ts
@@ -1,5 +1,5 @@
 import { GameApi, PlayerData, TechnoRules } from "@chronodivide/game-api";
-import { AiBuildingRules, getDefaultPlacementLocation, numBuildingsOwnedOfType } from "./building.js";
+import { AiBuildingRules, getDefaultPlacementLocation, numBuildingsOwnedOfType } from "./buildingRules.js";
 import { GlobalThreat } from "../threat/threat.js";
 
 export class BasicBuilding implements AiBuildingRules {

--- a/src/bot/logic/building/basicGroundUnit.ts
+++ b/src/bot/logic/building/basicGroundUnit.ts
@@ -1,6 +1,6 @@
 import { GameApi, PlayerData, TechnoRules } from "@chronodivide/game-api";
 import { GlobalThreat } from "../threat/threat.js";
-import { AiBuildingRules, getDefaultPlacementLocation, numBuildingsOwnedOfType } from "./building.js";
+import { AiBuildingRules, getDefaultPlacementLocation, numBuildingsOwnedOfType } from "./buildingRules.js";
 
 export class BasicGroundUnit implements AiBuildingRules {
     constructor(

--- a/src/bot/logic/building/buildingRules.ts
+++ b/src/bot/logic/building/buildingRules.ts
@@ -137,7 +137,7 @@ export const BUILDING_NAME_TO_RULES = new Map<string, AiBuildingRules>([
     ["GAWEAP", new BasicBuilding(15, 1)], // War Factory
     ["GAPILE", new BasicBuilding(12, 1)], // Barracks
     ["CMIN", new Harvester(15, 4, 2)], // Chrono Miner
-    ["ENGINEER", new BasicBuilding(100, 1)], // Engineer
+    ["ENGINEER", new BasicBuilding(10, 1, 1000)], // Engineer
     ["GADEPT", new BasicBuilding(1, 1, 10000)], // Repair Depot
     ["GAAIRC", new BasicBuilding(8, 1, 6000)], // Airforce Command
 
@@ -164,7 +164,7 @@ export const BUILDING_NAME_TO_RULES = new Map<string, AiBuildingRules>([
     ["NAWEAP", new BasicBuilding(15, 1)], // War Factory
     ["NAHAND", new BasicBuilding(12, 1)], // Barracks
     ["HARV", new Harvester(15, 4, 2)], // War Miner
-    ["SENGINEER", new BasicBuilding(100, 1)], // Soviet Engineer
+    ["SENGINEER", new BasicBuilding(10, 1, 1000)], // Soviet Engineer
     ["NADEPT", new BasicBuilding(1, 1, 10000)], // Repair Depot
     ["NARADR", new BasicBuilding(8, 1, 4000)], // Radar
     ["NANRCT", new PowerPlant()], // Nuclear Reactor

--- a/src/bot/logic/building/buildingRules.ts
+++ b/src/bot/logic/building/buildingRules.ts
@@ -91,7 +91,7 @@ function getTileDistances(startPoint: Point2D, tiles: Tile[]) {
     return ret
 }
 
-function distance(x1: number, y1 :number, x2:number, y2:number) {
+function distance(x1: number, y1: number, x2: number, y2: number) {
     var dx = x1 - x2
     var dy = y1 - y2;
     let tmp = dx * dx + dy * dy;
@@ -110,12 +110,12 @@ export function getDefaultPlacementLocation(
     space: number = 1,
 ): { rx: number; ry: number } | undefined {
     // Random location, preferably near start location.
-    let size: BuildingPlacementData = game.getBuildingPlacementData(technoRules.name);
+    const size: BuildingPlacementData = game.getBuildingPlacementData(technoRules.name);
     if (!size) {
         return undefined;
     }
-    let tiles = getAdjacencyTiles(game, playerData, technoRules)
-    let tileDistances = getTileDistances(startPoint, tiles)
+    const tiles = getAdjacencyTiles(game, playerData, technoRules)
+    const tileDistances = getTileDistances(startPoint, tiles)
 
     for (let tileDistance of tileDistances) {
         if (tileDistance.tile && game.canPlaceBuilding(playerData.name, technoRules.name, tileDistance.tile)) {
@@ -137,7 +137,7 @@ export const BUILDING_NAME_TO_RULES = new Map<string, AiBuildingRules>([
     ["GAWEAP", new BasicBuilding(15, 1)], // War Factory
     ["GAPILE", new BasicBuilding(12, 1)], // Barracks
     ["CMIN", new Harvester(15, 4, 2)], // Chrono Miner
-    ["ENGINEER", new BasicBuilding(1, 1, 10000)], // Engineer
+    ["ENGINEER", new BasicBuilding(100, 1)], // Engineer
     ["GADEPT", new BasicBuilding(1, 1, 10000)], // Repair Depot
     ["GAAIRC", new BasicBuilding(8, 1, 6000)], // Airforce Command
 
@@ -164,7 +164,7 @@ export const BUILDING_NAME_TO_RULES = new Map<string, AiBuildingRules>([
     ["NAWEAP", new BasicBuilding(15, 1)], // War Factory
     ["NAHAND", new BasicBuilding(12, 1)], // Barracks
     ["HARV", new Harvester(15, 4, 2)], // War Miner
-    ["SENGINEER", new BasicBuilding(1, 1, 10000)], // Soviet Engineer
+    ["SENGINEER", new BasicBuilding(100, 1)], // Soviet Engineer
     ["NADEPT", new BasicBuilding(1, 1, 10000)], // Repair Depot
     ["NARADR", new BasicBuilding(8, 1, 4000)], // Radar
     ["NANRCT", new PowerPlant()], // Nuclear Reactor

--- a/src/bot/logic/building/powerPlant.ts
+++ b/src/bot/logic/building/powerPlant.ts
@@ -1,5 +1,5 @@
 import { GameApi, PlayerData, TechnoRules } from "@chronodivide/game-api";
-import { AiBuildingRules, getDefaultPlacementLocation } from "./building.js";
+import { AiBuildingRules, getDefaultPlacementLocation } from "./buildingRules.js";
 import { GlobalThreat } from "../threat/threat.js";
 
 export class PowerPlant implements AiBuildingRules {

--- a/src/bot/logic/building/queueController.ts
+++ b/src/bot/logic/building/queueController.ts
@@ -13,7 +13,7 @@ import {
     BUILDING_NAME_TO_RULES,
     DEFAULT_BUILDING_PRIORITY,
     getDefaultPlacementLocation,
-} from "./building.js";
+} from "./buildingRules.js";
 
 export const QUEUES = [
     QueueType.Structures,

--- a/src/bot/logic/building/resourceCollectionBuilding.ts
+++ b/src/bot/logic/building/resourceCollectionBuilding.ts
@@ -6,7 +6,7 @@ import {
     getDefaultPlacementLocation,
     numBuildingsOwnedOfName,
     numBuildingsOwnedOfType,
-} from "./building.js";
+} from "./buildingRules.js";
 
 export class ResourceCollectionBuilding extends BasicBuilding {
     constructor(basePriority: number, maxNeeded: number, onlyBuildWhenFloatingCreditsAmount?: number) {

--- a/src/bot/logic/mission/missionFactories.ts
+++ b/src/bot/logic/mission/missionFactories.ts
@@ -7,6 +7,7 @@ import { AttackMissionFactory } from "./missions/attackMission.js";
 import { MissionController } from "./missionController.js";
 import { DefenceMissionFactory } from "./missions/defenceMission.js";
 import { DebugLogger } from "../common/utils.js";
+import { EngineerMissionFactory } from "./missions/engineerMission.js";
 
 export interface MissionFactory {
     getName(): string;
@@ -46,4 +47,5 @@ export const createMissionFactories = () => [
     new ScoutingMissionFactory(),
     new AttackMissionFactory(),
     new DefenceMissionFactory(),
+    new EngineerMissionFactory(),
 ];

--- a/src/bot/logic/mission/missions/engineerMission.ts
+++ b/src/bot/logic/mission/missions/engineerMission.ts
@@ -1,0 +1,61 @@
+import { GameApi, PlayerData } from "@chronodivide/game-api";
+import { GlobalThreat } from "../../threat/threat.js";
+import { Mission } from "../mission.js";
+import { ExpansionSquad } from "../../squad/behaviours/expansionSquad.js";
+import { MissionFactory } from "../missionFactories.js";
+import { OneTimeMission } from "./oneTimeMission.js";
+import { MatchAwareness } from "../../awareness.js";
+import { MissionController } from "../missionController.js";
+import { DebugLogger } from "../../common/utils.js";
+import { EngineerSquad } from "../../squad/behaviours/engineerSquad.js";
+
+/**
+ * A mission that tries to send an engineer into a building (e.g. to capture tech building or repair bridge)
+ */
+export class EngineerMission extends OneTimeMission {
+    constructor(uniqueName: string, priority: number, selectedTechBuilding: number, 
+        logger: DebugLogger) {
+        super(uniqueName, priority, () => new EngineerSquad(selectedTechBuilding), logger);
+    }
+}
+
+// Only try to capture tech buildings within this radius of the starting point.
+const MAX_TECH_CAPTURE_RADIUS = 50;
+
+const TECH_CHECK_INTERVAL_TICKS = 300;
+
+export class EngineerMissionFactory implements MissionFactory {
+    private lastCheckAt = 0;
+
+    getName(): string {
+        return "EngineerMissionFactory";
+    }
+
+    maybeCreateMissions(
+        gameApi: GameApi,
+        playerData: PlayerData,
+        matchAwareness: MatchAwareness,
+        missionController: MissionController,
+        logger: DebugLogger
+    ): void {
+        if (!(gameApi.getCurrentTick() > this.lastCheckAt + TECH_CHECK_INTERVAL_TICKS)) {
+            return;
+        }
+        this.lastCheckAt = gameApi.getCurrentTick();
+        const eligibleTechBuildings = gameApi.getVisibleUnits(playerData.name, "hostile", (r) => r.capturable && r.produceCashAmount > 0);
+
+        eligibleTechBuildings.forEach((techBuildingId) => {
+            missionController.addMission(new EngineerMission("capture-" + techBuildingId, 100, techBuildingId, logger));
+        });
+    }
+
+    onMissionFailed(
+        gameApi: GameApi,
+        playerData: PlayerData,
+        matchAwareness: MatchAwareness,
+        failedMission: Mission,
+        failureReason: undefined,
+        missionController: MissionController,
+    ): void {
+    }
+}

--- a/src/bot/logic/squad/behaviours/engineerSquad.ts
+++ b/src/bot/logic/squad/behaviours/engineerSquad.ts
@@ -1,0 +1,53 @@
+import { ActionsApi, GameApi, OrderType, PlayerData, SideType } from "@chronodivide/game-api";
+import { Squad } from "../squad.js";
+import { SquadAction, SquadBehaviour, disband, noop, requestSpecificUnits, requestUnits } from "../squadBehaviour.js";
+import { MatchAwareness } from "../../awareness.js";
+
+const CAPTURE_COOLDOWN_TICKS = 30;
+
+// Capture squad
+export class EngineerSquad implements SquadBehaviour {
+    private hasAttemptedCaptureWith: {
+        unitId: number;
+        gameTick: number;
+    } | null = null;
+
+    /**
+     * @param captureTarget ID of the target to try and capture/send engineer into.
+     */
+    constructor(private captureTarget: number) {
+    };
+
+    public onAiUpdate(
+        gameApi: GameApi,
+        actionsApi: ActionsApi,
+        playerData: PlayerData,
+        squad: Squad,
+        matchAwareness: MatchAwareness
+    ): SquadAction {
+        const engineerTypes = ["ENGINEER", "SENGINEER"];
+        const engineers = squad.getUnitsOfTypes(gameApi, ...engineerTypes);
+        if (engineers.length === 0) {
+            // Perhaps we deployed already (or the unit was destroyed), end the mission.
+            if (this.hasAttemptedCaptureWith !== null) {
+                return disband();
+            }
+            return requestUnits(engineerTypes, 100);
+        } else if (
+            !this.hasAttemptedCaptureWith ||
+            gameApi.getCurrentTick() > this.hasAttemptedCaptureWith.gameTick + CAPTURE_COOLDOWN_TICKS
+        ) {
+            actionsApi.orderUnits(
+                engineers.map((engineer) => engineer.id),
+                OrderType.Capture,
+                this.captureTarget
+            );
+            // Add a cooldown to deploy attempts.
+            this.hasAttemptedCaptureWith = {
+                unitId: engineers[0].id,
+                gameTick: gameApi.getCurrentTick(),
+            };
+        }
+        return noop();
+    }
+}


### PR DESCRIPTION
this was surprisingly easy to implement but I cheated a little by raising the priority of engineers (so there'd always be an engineer available to fulfil the EngineerMission). At some point I need to make the squad's `requestUnits` command hint the production queue to start building that unit.

Note that the bot will constantly try to capture derricks that it can see, even if they are near the enemy. This is almost faithful to the original AI though, so I'm leaving that in.