### PR TITLE
add permanent defence mission

### DIFF
--- a/src/bot/logic/mission/mission.ts
+++ b/src/bot/logic/mission/mission.ts
@@ -168,15 +168,22 @@ export type MissionActionRequestUnits = {
     unitNames: string[];
     priority: number;
 };
+
 export type MissionActionRequestSpecificUnits = {
     type: "requestSpecific";
     unitIds: number[];
     priority: number;
 };
+
 export type MissionActionGrabFreeCombatants = {
     type: "requestCombatants";
     point: Vector2;
     radius: number;
+};
+
+export type MissionActionReleaseUnits = {
+    type: "releaseUnits";
+    unitIds: number[];
 };
 
 export const noop = () =>
@@ -195,9 +202,12 @@ export const requestSpecificUnits = (unitIds: number[], priority: number) =>
 export const grabCombatants = (point: Vector2, radius: number) =>
     ({ type: "requestCombatants", point, radius }) as MissionActionGrabFreeCombatants;
 
+export const releaseUnits = (unitIds: number[]) => ({ type: "releaseUnits", unitIds }) as MissionActionReleaseUnits;
+
 export type MissionAction =
     | MissionActionNoop
     | MissionActionDisband
     | MissionActionRequestUnits
     | MissionActionRequestSpecificUnits
-    | MissionActionGrabFreeCombatants;
+    | MissionActionGrabFreeCombatants
+    | MissionActionReleaseUnits;

--- a/src/bot/logic/mission/mission.ts
+++ b/src/bot/logic/mission/mission.ts
@@ -154,6 +154,11 @@ export abstract class Mission<BehaviourType extends MissionBehaviour, FailureRea
     }
 }
 
+export type MissionWithAction<T extends MissionAction> = {
+    mission: Mission<any>;
+    action: T;
+};
+
 export type MissionActionNoop = {
     type: "noop";
 };
@@ -192,17 +197,31 @@ export const noop = () =>
     }) as MissionActionNoop;
 
 export const disbandMission = (reason?: any) => ({ type: "disband", reason }) as MissionActionDisband;
+export const isDisbandMission = (a: MissionWithAction<MissionAction>): a is MissionWithAction<MissionActionDisband> =>
+    a.action.type === "disband";
 
 export const requestUnits = (unitNames: string[], priority: number) =>
     ({ type: "request", unitNames, priority }) as MissionActionRequestUnits;
+export const isRequestUnits = (
+    a: MissionWithAction<MissionAction>,
+): a is MissionWithAction<MissionActionRequestUnits> => a.action.type === "request";
 
 export const requestSpecificUnits = (unitIds: number[], priority: number) =>
     ({ type: "requestSpecific", unitIds, priority }) as MissionActionRequestSpecificUnits;
+export const isRequestSpecificUnits = (
+    a: MissionWithAction<MissionAction>,
+): a is MissionWithAction<MissionActionRequestSpecificUnits> => a.action.type === "requestSpecific";
 
 export const grabCombatants = (point: Vector2, radius: number) =>
     ({ type: "requestCombatants", point, radius }) as MissionActionGrabFreeCombatants;
+export const isGrabCombatants = (
+    a: MissionWithAction<MissionAction>,
+): a is MissionWithAction<MissionActionGrabFreeCombatants> => a.action.type === "requestCombatants";
 
 export const releaseUnits = (unitIds: number[]) => ({ type: "releaseUnits", unitIds }) as MissionActionReleaseUnits;
+export const isReleaseUnits = (
+    a: MissionWithAction<MissionAction>,
+): a is MissionWithAction<MissionActionReleaseUnits> => a.action.type === "releaseUnits";
 
 export type MissionAction =
     | MissionActionNoop

--- a/src/bot/logic/mission/missionController.ts
+++ b/src/bot/logic/mission/missionController.ts
@@ -103,7 +103,12 @@ export class MissionController {
 
         // Release units
         missionActions.filter(isReleaseUnits).forEach((a) => {
-            // TODO
+            a.action.unitIds.forEach((unitId) => {
+                if (this.unitIdToMission.get(unitId)?.getUniqueName() === a.mission.getUniqueName()) {
+                    a.mission.removeUnit(unitId);
+                    this.unitIdToMission.delete(unitId);
+                }
+            });
         });
 
         // Request specific units by ID

--- a/src/bot/logic/mission/missions/defenceMission.ts
+++ b/src/bot/logic/mission/missions/defenceMission.ts
@@ -1,14 +1,14 @@
 import { ActionsApi, GameApi, PlayerData, UnitData, Vector2 } from "@chronodivide/game-api";
 import { MatchAwareness } from "../../awareness.js";
 import { MissionController } from "../missionController.js";
-import { Mission, MissionAction, disbandMission, noop, releaseUnits, requestUnits } from "../mission.js";
+import { Mission, MissionAction, noop, releaseUnits, requestUnits } from "../mission.js";
 import { MissionFactory } from "../missionFactories.js";
 import { CombatSquad } from "../behaviours/combatSquad.js";
-import { RetreatMission } from "./retreatMission.js";
 import { DebugLogger, isOwnedByNeutral } from "../../common/utils.js";
 import { ActionBatcher } from "../actionBatcher.js";
 
 export const MAX_PRIORITY = 30;
+export const PRIORITY_INCREASE_PER_TICK_RATIO = 1.025;
 
 /**
  * A mission that tries to defend a certain area.
@@ -68,7 +68,7 @@ export class DefenceMission extends Mission<CombatSquad> {
                 } found in area ${this.radius})`,
             );
             this.getBehaviour.setAttackArea(new Vector2(foundTargets[0].tile.rx, foundTargets[0].tile.ry));
-            this.priority = Math.min(MAX_PRIORITY, this.priority + 0.05);
+            this.priority = Math.min(MAX_PRIORITY, this.priority * PRIORITY_INCREASE_PER_TICK_RATIO);
         }
         return requestUnits(["E1", "E2", "FV", "HTK", "MTNK", "HTNK"], this.priority);
     }

--- a/src/bot/logic/mission/missions/defenceMission.ts
+++ b/src/bot/logic/mission/missions/defenceMission.ts
@@ -1,21 +1,19 @@
 import { ActionsApi, GameApi, PlayerData, UnitData, Vector2 } from "@chronodivide/game-api";
 import { MatchAwareness } from "../../awareness.js";
 import { MissionController } from "../missionController.js";
-import { Mission, MissionAction, disbandMission, noop, requestUnits } from "../mission.js";
+import { Mission, MissionAction, disbandMission, noop, releaseUnits, requestUnits } from "../mission.js";
 import { MissionFactory } from "../missionFactories.js";
 import { CombatSquad } from "../behaviours/combatSquad.js";
 import { RetreatMission } from "./retreatMission.js";
 import { DebugLogger, isOwnedByNeutral } from "../../common/utils.js";
 import { ActionBatcher } from "../actionBatcher.js";
 
-export enum DefenceFailReason {
-    NoTargets,
-}
+export const MAX_PRIORITY = 30;
 
 /**
  * A mission that tries to defend a certain area.
  */
-export class DefenceMission extends Mission<CombatSquad, DefenceFailReason> {
+export class DefenceMission extends Mission<CombatSquad> {
     constructor(
         uniqueName: string,
         private priority: number,
@@ -55,8 +53,13 @@ export class DefenceMission extends Mission<CombatSquad, DefenceFailReason> {
         }
 
         if (foundTargets.length === 0) {
-            this.logger(`(Defence Mission ${this.getUniqueName()}): No targets found, disbanding.`);
-            return disbandMission(DefenceFailReason.NoTargets);
+            this.priority = 0;
+            if (this.getUnitIds().length > 0) {
+                this.logger(`(Defence Mission ${this.getUniqueName()}): No targets found, releasing units.`);
+                return releaseUnits(this.getUnitIds());
+            } else {
+                return noop();
+            }
         } else {
             const targetUnit = foundTargets[0];
             this.logger(
@@ -65,9 +68,9 @@ export class DefenceMission extends Mission<CombatSquad, DefenceFailReason> {
                 } found in area ${this.radius})`,
             );
             this.getBehaviour.setAttackArea(new Vector2(foundTargets[0].tile.rx, foundTargets[0].tile.ry));
+            this.priority = Math.min(MAX_PRIORITY, this.priority + 0.05);
         }
-        return requestUnits(["E1", "E2"], this.priority);
-        //return noop();
+        return requestUnits(["E1", "E2", "FV", "HTK", "MTNK", "HTNK"], this.priority);
     }
 }
 
@@ -120,16 +123,7 @@ export class DefenceMissionFactory implements MissionFactory {
                     playerData.startLocation,
                     defendableRadius * 1.2,
                     logger,
-                ).then((unitIds, squad) => {
-                    missionController.addMission(
-                        new RetreatMission(
-                            "retreat-from-globalDefence" + gameApi.getCurrentTick(),
-                            matchAwareness.getMainRallyPoint(),
-                            unitIds,
-                            logger,
-                        ),
-                    );
-                }),
+                ),
             );
         }
     }


### PR DESCRIPTION
defence mission now ramps up in priority if there are enemies to defend against, and drops to 0 (and releases all its units) when all enemies are defeated.

also use type guards to clean up some of the casting in `missionController`.