### PR TITLE
Fix top-of-map placement issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@chronodivide/game-api": {
-            "version": "0.51.1",
-            "resolved": "https://registry.npmjs.org/@chronodivide/game-api/-/game-api-0.51.1.tgz",
-            "integrity": "sha512-LLPiq6wWAu0R4l7xft6mK1dfE2svaQTSOMg8IYHHioNE3ZxrKlXUg2eBlU4ixHjFkHvhIiXR2/81KypDKVdV5w==",
+            "version": "0.51.2",
+            "resolved": "https://registry.npmjs.org/@chronodivide/game-api/-/game-api-0.51.2.tgz",
+            "integrity": "sha512-amMWAwFKuUQ7vEq2BHmWTFiL02dtEF7TEPcgKPl+DLMJsfcRM7+I8pkA4wvuMgyU/dWFz7xOmoyJanML6UtH0g==",
             "dev": true,
             "requires": {
                 "@types/three": "^0.93.31",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
     "name": "@supalosa/chronodivide-bot",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@chronodivide/game-api": {
-            "version": "0.50.1",
-            "resolved": "https://registry.npmjs.org/@chronodivide/game-api/-/game-api-0.50.1.tgz",
-            "integrity": "sha512-JNEiPfYDje3YNJtjqz2EzhbRia3P5tP5TBQDV0z+sSEaFGgyPTomAScKGpQf+fnLOX7YhH3sc3hA19RBnl4ESQ==",
+            "version": "0.51.1",
+            "resolved": "https://registry.npmjs.org/@chronodivide/game-api/-/game-api-0.51.1.tgz",
+            "integrity": "sha512-LLPiq6wWAu0R4l7xft6mK1dfE2svaQTSOMg8IYHHioNE3ZxrKlXUg2eBlU4ixHjFkHvhIiXR2/81KypDKVdV5w==",
             "dev": true,
             "requires": {
                 "@types/three": "^0.93.31",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     },
     "license": "UNLICENSED",
     "devDependencies": {
-        "@chronodivide/game-api": "^0.51.1",
+        "@chronodivide/game-api": "^0.51.2",
         "@types/node": "^14.17.32",
         "prettier": "3.0.3",
         "typescript": "^4.3.5"
     },
     "peerDependencies": {
-        "@chronodivide/game-api": "^0.51.1"
+        "@chronodivide/game-api": "^0.51.2"
     },
     "dependencies": {
         "@datastructures-js/priority-queue": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@supalosa/chronodivide-bot",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "description": "Example bot for Chrono Divide",
     "repository": "https://github.com/Supalosa/supalosa-chronodivide-bot",
     "main": "dist/exampleBot.js",
@@ -13,13 +13,13 @@
     },
     "license": "UNLICENSED",
     "devDependencies": {
-        "@chronodivide/game-api": "^0.50.1",
+        "@chronodivide/game-api": "^0.51.1",
         "@types/node": "^14.17.32",
         "prettier": "3.0.3",
         "typescript": "^4.3.5"
     },
     "peerDependencies": {
-        "@chronodivide/game-api": "^0.50.1"
+        "@chronodivide/game-api": "^0.51.1"
     },
     "dependencies": {
         "@datastructures-js/priority-queue": "^6.3.0",

--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -5,7 +5,7 @@ import { SectorCache } from "./logic/map/sector.js";
 import { MissionController } from "./logic/mission/missionController.js";
 import { QueueController } from "./logic/building/queueController.js";
 import { MatchAwareness, MatchAwarenessImpl } from "./logic/awareness.js";
-import { formatTimeDuration } from "./logic/common/utils.js";
+import { Countries, formatTimeDuration } from "./logic/common/utils.js";
 
 const DEBUG_STATE_UPDATE_INTERVAL_SECONDS = 6;
 
@@ -23,7 +23,7 @@ export class SupalosaBot extends Bot {
 
     constructor(
         name: string,
-        country: string,
+        country: Countries,
         private tryAllyWith: string[] = [],
         private enableLogging = true,
     ) {

--- a/src/bot/logic/building/buildingRules.ts
+++ b/src/bot/logic/building/buildingRules.ts
@@ -52,6 +52,13 @@ export function numBuildingsOwnedOfName(game: GameApi, playerData: PlayerData, n
     return game.getVisibleUnits(playerData.name, "self", (r) => r.name === name).length;
 }
 
+type TileRange = {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+};
+
 /**
  * Computes a rect 'centered' around a structure of a certain size with an additional radius (`adjacent`).
  * The radius is optionally expanded by the size of the new building.
@@ -64,13 +71,43 @@ export function numBuildingsOwnedOfName(game: GameApi, playerData: PlayerData, n
  * @param newBuildingSize? Size of the new building
  * @returns
  */
-function computeAdjacentRect(point: Vector2, t: Size, adjacent: number, newBuildingSize?: Size) {
+function computeAdjacentRect(point: Vector2, t: Size, adjacent: number, newBuildingSize?: Size): TileRange {
     return {
         x: point.x - adjacent - (newBuildingSize?.width || 0),
         y: point.y - adjacent - (newBuildingSize?.height || 0),
         width: t.width + 2 * adjacent + (newBuildingSize?.width || 0),
         height: t.height + 2 * adjacent + (newBuildingSize?.height || 0),
     };
+}
+
+function getAdjacentTiles(game: GameApi, range: TileRange, onWater: boolean) {
+    const baseTile = game.mapApi.getTile(range.x, range.y);
+    if (!baseTile) {
+        // base tile might be off the map: fall back to slow method
+        return getAdjacentTilesSlow(game, range, onWater);
+    }
+    // use the bulk API to get all tiles from the baseTile to the (baseTile + range)
+    const adjacentTiles = game.mapApi
+        .getTilesInRect(baseTile, {
+            width: range.width,
+            height: range.height,
+        })
+        .filter((tile) => !onWater || tile.landType === LandType.Water);
+    return adjacentTiles;
+}
+
+function getAdjacentTilesSlow(game: GameApi, range: TileRange, onWater: boolean) {
+    // this method scans each tile in the range
+    const result: Tile[] = [];
+    for (let x = range.x; x < range.x + range.width; ++x) {
+        for (let y = range.y; y < range.y + range.height; ++y) {
+            const tile = game.mapApi.getTile(x, y);
+            if (tile) {
+                result.push(tile);
+            }
+        }
+    }
+    return result;
 }
 
 export function getAdjacencyTiles(
@@ -98,16 +135,10 @@ export function getAdjacencyTiles(
             height: foundation?.height,
         };
         const range = computeAdjacentRect(buildingBase, buildingSize, technoRules.adjacent, placementRules.foundation);
-        const baseTile = game.mapApi.getTile(range.x, range.y);
-        if (!baseTile) {
+        const adjacentTiles = getAdjacentTiles(game, range, onWater);
+        if (adjacentTiles.length === 0) {
             continue;
         }
-        const adjacentTiles = game.mapApi
-            .getTilesInRect(baseTile, {
-                width: range.width,
-                height: range.height,
-            })
-            .filter((tile) => !onWater || tile.landType === LandType.Water);
         tiles.push(...adjacentTiles);
 
         // Prevent placing the new building on tiles that would cause it to overlap with this building.

--- a/src/bot/logic/common/utils.ts
+++ b/src/bot/logic/common/utils.ts
@@ -1,10 +1,18 @@
 import { GameObjectData, TechnoRules, UnitData } from "@chronodivide/game-api";
 
+export enum Countries {
+    USA = "Americans",
+    KOREA = "Alliance",
+    FRANCE = "French",
+    GERMANY = "Germans",
+    GREAT_BRITAIN = "British",
+    LIBYA = "Africans",
+    IRAQ = "Arabs",
+    CUBA = "Confederation",
+    RUSSIA = "Russians",
+}
+
 export type DebugLogger = (message: string, sayInGame?: boolean) => void;
-
-const SOVIET_COUNTRY_NAMES = ["Africans", "Arabs", "Confederation", "Russians"];
-
-export const isSoviet = (countryName: string) => SOVIET_COUNTRY_NAMES.includes(countryName);
 
 export const isOwnedByNeutral = (unitData: UnitData | undefined) => unitData?.owner === "@@NEUTRAL@@";
 

--- a/src/exampleBot.ts
+++ b/src/exampleBot.ts
@@ -9,21 +9,10 @@ import {
     cdapi,
 } from "@chronodivide/game-api";
 import { SupalosaBot } from "./bot/bot.js";
+import { Countries } from "./bot/logic/common/utils.js";
 
 // The game will automatically end after this time. This is to handle stalemates.
 const MAX_GAME_LENGTH_SECONDS: number | null = 7200; // 7200 = two hours
-
-enum Countries {
-    USA = "Americans",
-    KOREA = "Alliance",
-    FRANCE = "French",
-    GERMANY = "Germans",
-    GREAT_BRITAIN = "British",
-    LIBYA = "Africans",
-    IRAQ = "Arabs",
-    CUBA = "Confederation",
-    RUSSIA = "Russians",
-}
 
 async function main() {
     /*
@@ -95,8 +84,8 @@ async function main() {
         ...baseSettings,
         online: false,
         agents: [
-            new SupalosaBot(firstBotName, Countries.FRANCE, [], true).setDebugMode(true),
-            new SupalosaBot(secondBotName, Countries.RUSSIA, [], false),
+            new SupalosaBot(firstBotName, Countries.FRANCE, [], false),
+            new SupalosaBot(secondBotName, Countries.RUSSIA, [], true).setDebugMode(true),
         ],
     };
 

--- a/src/exampleBot.ts
+++ b/src/exampleBot.ts
@@ -1,9 +1,29 @@
 import "dotenv/config";
-import { Agent, Bot, CreateBaseOpts, CreateOfflineOpts, CreateOnlineOpts, cdapi } from "@chronodivide/game-api";
+import {
+    Agent,
+    Bot,
+    Country,
+    CreateBaseOpts,
+    CreateOfflineOpts,
+    CreateOnlineOpts,
+    cdapi,
+} from "@chronodivide/game-api";
 import { SupalosaBot } from "./bot/bot.js";
 
 // The game will automatically end after this time. This is to handle stalemates.
 const MAX_GAME_LENGTH_SECONDS: number | null = 7200; // 7200 = two hours
+
+enum Countries {
+    USA = "Americans",
+    KOREA = "Alliance",
+    FRANCE = "French",
+    GERMANY = "Germans",
+    GREAT_BRITAIN = "British",
+    LIBYA = "Africans",
+    IRAQ = "Arabs",
+    CUBA = "Confederation",
+    RUSSIA = "Russians",
+}
 
 async function main() {
     /*
@@ -33,7 +53,7 @@ async function main() {
     heckcorners_b_golden.map,hecklvl.map,heckrvr.map,hecktvt.map,isleland.map,jungleofvietnam.map,2_malibu_cliffs_le.map,mojosprt.map,4_montana_dmz_le.map,6_near_ore_far.map,8_near_ore_far.map,
     offensedefense.map,ore2_startfixed.map,rekoool_fast_6players.mpr,rekoool_fast_8players.mpr,riverram.map,tourofegypt.map,unrepent.map,sinkswim_yr_port.map
     */
-    const mapName = "mp03t4.map";
+    const mapName = "heckcorners_b.map";
     // Bot names must be unique in online mode
     const timestamp = String(Date.now()).substr(-6);
     const firstBotName = `Joe${timestamp}`;
@@ -45,20 +65,6 @@ async function main() {
 
     console.log("Server URL: " + process.env.SERVER_URL!);
     console.log("Client URL: " + process.env.CLIENT_URL!);
-
-    /*
-    Countries:
-    0=Americans
-    1=Alliance -> Korea
-    2=French
-    3=Germans
-    4=British
-
-    5=Africans -> Libya
-    6=Arabs -> Iraq
-    7=Confederation -> Cuba
-    8=Russians
-    */
 
     const baseSettings: CreateBaseOpts = {
         buildOffAlly: false,
@@ -79,8 +85,8 @@ async function main() {
         serverUrl: process.env.SERVER_URL!,
         clientUrl: process.env.CLIENT_URL!,
         agents: [
-            new SupalosaBot(process.env.ONLINE_BOT_NAME ?? firstBotName, "Americans"),
-            { name: process.env.PLAYER_NAME ?? secondBotName, country: "French" },
+            new SupalosaBot(process.env.ONLINE_BOT_NAME ?? firstBotName, Countries.USA),
+            { name: process.env.PLAYER_NAME ?? secondBotName, country: Countries.FRANCE },
         ] as [Bot, ...Agent[]],
         botPassword: process.env.ONLINE_BOT_PASSWORD ?? "default",
     };
@@ -89,8 +95,8 @@ async function main() {
         ...baseSettings,
         online: false,
         agents: [
-            new SupalosaBot(firstBotName, "French", [], true).setDebugMode(true),
-            new SupalosaBot(secondBotName, "Russians", [], false),
+            new SupalosaBot(firstBotName, Countries.FRANCE, [], true).setDebugMode(true),
+            new SupalosaBot(secondBotName, Countries.RUSSIA, [], false),
         ],
     };
 
@@ -98,10 +104,10 @@ async function main() {
         ...baseSettings,
         online: false,
         agents: [
-            new SupalosaBot(firstBotName, "French", [firstBotName], false),
-            new SupalosaBot(secondBotName, "Russians", [firstBotName], true).setDebugMode(true),
-            new SupalosaBot(thirdBotName, "Russians", [fourthBotName], false),
-            new SupalosaBot(fourthBotName, "French", [thirdBotName], false),
+            new SupalosaBot(firstBotName, Countries.FRANCE, [firstBotName], false),
+            new SupalosaBot(secondBotName, Countries.RUSSIA, [firstBotName], true).setDebugMode(true),
+            new SupalosaBot(thirdBotName, Countries.RUSSIA, [fourthBotName], false),
+            new SupalosaBot(fourthBotName, Countries.FRANCE, [thirdBotName], false),
         ],
     };
 


### PR DESCRIPTION
The default structure placement code works by iterating over the agent's buildings, then calling `getTilesInRect` with the existing building's location and the new building's `adjacent` value. These are appended to a set of locations to test for placement.

`getTilesInRect` requires a starting tile, which is retrieved by `GameApi.mapApi.getTile`.

**Problem:** If this tile is outside the playable area, the API returns `undefined`  for the tile and there will be no valid locations to test!

**Temporary fix:** If the starting tile is outside the map, we revert to a slower mode where we test every cell in the adjacency range. This is **very** slow but at least the agent can do something. The placement test code only runs when a structure is complete, anyway.