### PR TITLE
Reduce amount of `getUnitData` calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ replays/
 .env
 *.ini
 *.map
+*.mpr

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ replays/
 *.cpuprofile
 .env
 *.ini
+*.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@supalosa/chronodivide-bot",
-    "version": "0.5.4",
+    "version": "0.6.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "name": "@supalosa/chronodivide-bot",
-    "version": "0.5.4",
+    "version": "0.6.0",
     "description": "Example bot for Chrono Divide",
     "repository": "https://github.com/Supalosa/supalosa-chronodivide-bot",
-    "main": "dist/exampleBot.js",
+    "main": "dist/main.js",
     "type": "module",
     "scripts": {
         "build": "tsc -p .",

--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -51,7 +51,9 @@ export class SupalosaBot extends Bot {
 
         this.logBotStatus(`Map bounds: ${this.knownMapBounds.width}, ${this.knownMapBounds.height}`);
 
-        this.tryAllyWith.forEach((playerName) => this.actionsApi.toggleAlliance(playerName, true));
+        this.tryAllyWith
+            .filter((playerName) => playerName !== this.name)
+            .forEach((playerName) => this.actionsApi.toggleAlliance(playerName, true));
     }
 
     override onGameTick(game: GameApi) {

--- a/src/bot/logic/awareness.ts
+++ b/src/bot/logic/awareness.ts
@@ -131,14 +131,6 @@ export class MatchAwarenessImpl implements MatchAwareness {
         return scaledGroundPower > scaledGroundThreat || scaledAirPower > scaledAirThreat;
     }
 
-    private isHostileUnit(unit: UnitData | undefined, hostilePlayerNames: string[]): boolean {
-        if (!unit) {
-            return false;
-        }
-
-        return hostilePlayerNames.includes(unit.owner);
-    }
-
     public onGameStart(gameApi: GameApi, playerData: PlayerData) {
         this.scoutingManager.onGameStart(gameApi, playerData, this.sectorCache);
     }
@@ -154,17 +146,6 @@ export class MatchAwarenessImpl implements MatchAwareness {
         if (updateRatio && updateRatio < 1.0) {
             this.logger(`${updateRatio * 100.0}% of sectors updated in last 60 seconds.`);
         }
-
-        const hostilePlayerNames = game
-            .getPlayers()
-            .map((name) => game.getPlayerData(name))
-            .filter(
-                (other) =>
-                    other.name !== playerData.name &&
-                    other.isCombatant &&
-                    !game.areAlliedPlayers(playerData.name, other.name),
-            )
-            .map((other) => other.name);
 
         // Build the quadtree, if this is too slow we should consider doing this periodically.
         const hostileUnitIds = game.getVisibleUnits(playerData.name, "enemy");

--- a/src/bot/logic/building/queueController.ts
+++ b/src/bot/logic/building/queueController.ts
@@ -51,8 +51,11 @@ type QueueState = {
     topItem: TechnoRulesWithPriority | undefined;
 };
 
+const REPAIR_CHECK_INTERVAL = 30;
+
 export class QueueController {
     private queueStates: QueueState[] = [];
+    private lastRepairCheckAt = 0;
 
     constructor() {}
 
@@ -106,7 +109,7 @@ export class QueueController {
         });
 
         // Repair is simple - just repair everything that's damaged.
-        if (playerData.credits > 0) {
+        if (playerData.credits > 0 && game.getCurrentTick() > this.lastRepairCheckAt + REPAIR_CHECK_INTERVAL) {
             game.getVisibleUnits(playerData.name, "self", (r) => r.repairable).forEach((unitId) => {
                 const unit = game.getUnitData(unitId);
                 if (!unit || !unit.hitPoints || !unit.maxHitPoints || unit.hasWrenchRepair) {
@@ -116,6 +119,7 @@ export class QueueController {
                     actionsApi.toggleRepairWrench(unitId);
                 }
             });
+            this.lastRepairCheckAt = REPAIR_CHECK_INTERVAL;
         }
     }
 

--- a/src/bot/logic/building/queueController.ts
+++ b/src/bot/logic/building/queueController.ts
@@ -119,7 +119,7 @@ export class QueueController {
                     actionsApi.toggleRepairWrench(unitId);
                 }
             });
-            this.lastRepairCheckAt = REPAIR_CHECK_INTERVAL;
+            this.lastRepairCheckAt = game.getCurrentTick();
         }
     }
 

--- a/src/bot/logic/common/rulesCache.ts
+++ b/src/bot/logic/common/rulesCache.ts
@@ -1,0 +1,46 @@
+import { GameApi, TechnoRules } from "@chronodivide/game-api";
+
+// checking technorules directly reduces the amount of calls to getUnitData(), which is a relatively expensive function.
+// A null value indicates an object that does not have TechnoRules.
+const technoRulesCache: { [rulesName: string]: TechnoRules | null } = {};
+
+export const getCachedTechnoRules = (gameApi: GameApi, unitId: number): TechnoRules | null => {
+    const gameObject = gameApi.getGameObjectData(unitId);
+    if (!gameObject) {
+        return null;
+    }
+    const { rulesApi } = gameApi;
+    const { name } = gameObject;
+
+    if (technoRulesCache[name]) {
+        // object is present in cache, either with TechnoRules or null (indicating that it does not have TechnoRules)
+        return technoRulesCache[name];
+    }
+
+    const aircraftRules = rulesApi.aircraftRules.get(name);
+    if (aircraftRules) {
+        technoRulesCache[name] = aircraftRules;
+        return aircraftRules;
+    }
+
+    const buildingRules = rulesApi.buildingRules.get(name);
+    if (buildingRules) {
+        technoRulesCache[name] = buildingRules;
+        return buildingRules;
+    }
+
+    const infantryRules = rulesApi.infantryRules.get(name);
+    if (infantryRules) {
+        technoRulesCache[name] = infantryRules;
+        return infantryRules;
+    }
+
+    const vehicleRules = rulesApi.vehicleRules.get(name);
+    if (vehicleRules) {
+        technoRulesCache[name] = vehicleRules;
+        return vehicleRules;
+    }
+
+    technoRulesCache[name] = null;
+    return null;
+};

--- a/src/bot/logic/mission/mission.ts
+++ b/src/bot/logic/mission/mission.ts
@@ -1,4 +1,4 @@
-import { ActionsApi, GameApi, PlayerData, Tile, UnitData, Vector2 } from "@chronodivide/game-api";
+import { ActionsApi, GameApi, GameObjectData, PlayerData, Tile, UnitData, Vector2 } from "@chronodivide/game-api";
 import { MatchAwareness } from "../awareness.js";
 import { DebugLogger } from "../common/utils.js";
 import { ActionBatcher } from "./actionBatcher.js";
@@ -97,6 +97,14 @@ export abstract class Mission<FailureReasons = undefined> {
     public getUnits(gameApi: GameApi): UnitData[] {
         return this.unitIds
             .map((unitId) => gameApi.getUnitData(unitId))
+            .filter((unit) => unit != null)
+            .map((unit) => unit!);
+    }
+
+    // returns GameObjectData, which is significantly faster to retrieve.
+    public getUnitsFast(gameApi: GameApi): GameObjectData[] {
+        return this.unitIds
+            .map((unitId) => gameApi.getGameObjectData(unitId))
             .filter((unit) => unit != null)
             .map((unit) => unit!);
     }

--- a/src/bot/logic/mission/mission.ts
+++ b/src/bot/logic/mission/mission.ts
@@ -44,12 +44,11 @@ export abstract class Mission<FailureReasons = undefined> {
 
     // TODO call this
     protected updateCenterOfMass(gameApi: GameApi) {
-        const movableUnitTiles = this.unitIds
-            .map((unitId) => gameApi.getUnitData(unitId))
-            .filter((unit) => unit?.canMove)
+        const unitTiles = this.unitIds
+            .map((unitId) => gameApi.getGameObjectData(unitId))
             .map((unit) => unit?.tile)
             .filter((tile) => !!tile) as Tile[];
-        const tileMetrics = calculateCenterOfMass(movableUnitTiles);
+        const tileMetrics = calculateCenterOfMass(unitTiles);
         if (tileMetrics) {
             this.centerOfMass = tileMetrics.centerOfMass;
             this.maxDistanceToCenterOfMass = tileMetrics.maxDistance;

--- a/src/bot/logic/mission/missions/attackMission.ts
+++ b/src/bot/logic/mission/missions/attackMission.ts
@@ -91,7 +91,7 @@ export class AttackMission extends Mission<AttackFailReason> {
         matchAwareness: MatchAwareness,
         actionBatcher: ActionBatcher,
     ) {
-        const currentComposition: UnitComposition = countBy(this.getUnitsFast(gameApi), (unit) => unit.name);
+        const currentComposition: UnitComposition = countBy(this.getUnitsGameObjectData(gameApi), (unit) => unit.name);
 
         const missingUnits = Object.entries(this.composition).filter(([unitType, targetAmount]) => {
             return !currentComposition[unitType] || currentComposition[unitType] < targetAmount;

--- a/src/bot/logic/mission/missions/attackMission.ts
+++ b/src/bot/logic/mission/missions/attackMission.ts
@@ -91,7 +91,7 @@ export class AttackMission extends Mission<AttackFailReason> {
         matchAwareness: MatchAwareness,
         actionBatcher: ActionBatcher,
     ) {
-        const currentComposition: UnitComposition = countBy(this.getUnits(gameApi), (unit) => unit.name);
+        const currentComposition: UnitComposition = countBy(this.getUnitsFast(gameApi), (unit) => unit.name);
 
         const missingUnits = Object.entries(this.composition).filter(([unitType, targetAmount]) => {
             return !currentComposition[unitType] || currentComposition[unitType] < targetAmount;

--- a/src/bot/logic/mission/missions/squads/combatSquad.ts
+++ b/src/bot/logic/mission/missions/squads/combatSquad.ts
@@ -77,20 +77,23 @@ export class CombatSquad implements Squad {
             this.lastCommand = gameApi.getCurrentTick();
             const centerOfMass = mission.getCenterOfMass();
             const maxDistance = mission.getMaxDistanceToCenterOfMass();
-            const units = mission.getUnitsMatching(gameApi, (r) => r.rules.isSelectableCombatant);
+            const unitIds = mission.getUnitsMatchingByRule(gameApi, (r) => r.isSelectableCombatant);
+            const units = unitIds
+                .map((unitId) => gameApi.getUnitData(unitId))
+                .filter((unit): unit is UnitData => !!unit);
 
             // Only use ground units for center of mass.
-            const groundUnits = mission.getUnitsMatching(
+            const groundUnitIds = mission.getUnitsMatchingByRule(
                 gameApi,
                 (r) =>
-                    r.rules.isSelectableCombatant &&
-                    (r.rules.movementZone === MovementZone.Infantry ||
-                        r.rules.movementZone === MovementZone.Normal ||
-                        r.rules.movementZone === MovementZone.InfantryDestroyer),
+                    r.isSelectableCombatant &&
+                    (r.movementZone === MovementZone.Infantry ||
+                        r.movementZone === MovementZone.Normal ||
+                        r.movementZone === MovementZone.InfantryDestroyer),
             );
 
             if (this.state === SquadState.Gathering) {
-                const requiredGatherRadius = GameMath.sqrt(groundUnits.length) * GATHER_RATIO + MIN_GATHER_RADIUS;
+                const requiredGatherRadius = GameMath.sqrt(groundUnitIds.length) * GATHER_RATIO + MIN_GATHER_RADIUS;
                 if (
                     centerOfMass &&
                     maxDistance &&
@@ -106,7 +109,7 @@ export class CombatSquad implements Squad {
                 }
             } else {
                 const targetPoint = this.targetArea || playerData.startLocation;
-                const requiredGatherRadius = GameMath.sqrt(groundUnits.length) * GATHER_RATIO + MAX_GATHER_RADIUS;
+                const requiredGatherRadius = GameMath.sqrt(groundUnitIds.length) * GATHER_RATIO + MAX_GATHER_RADIUS;
                 if (
                     centerOfMass &&
                     maxDistance &&

--- a/src/dummyBot/dummyBot.ts
+++ b/src/dummyBot/dummyBot.ts
@@ -1,0 +1,9 @@
+import { Bot } from "@chronodivide/game-api";
+import { Countries } from "../bot/logic/common/utils.js";
+
+/* An empty bot implementation for performance testing */
+export class DummyBot extends Bot {
+    constructor(name: string, country: Countries) {
+        super(name, country);
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import { Agent, Bot, CreateBaseOpts, CreateOfflineOpts, CreateOnlineOpts, cdapi } from "@chronodivide/game-api";
 import { SupalosaBot } from "./bot/bot.js";
+import { DummyBot } from "./dummyBot/dummyBot.js";
 import { Countries } from "./bot/logic/common/utils.js";
 
 // The game will automatically end after this time. This is to handle stalemates.
@@ -76,8 +77,8 @@ async function main() {
         ...baseSettings,
         online: false,
         agents: [
-            new SupalosaBot(firstBotName, Countries.FRANCE, [], false),
-            new SupalosaBot(secondBotName, Countries.RUSSIA, [], true).setDebugMode(true),
+            new SupalosaBot(firstBotName, Countries.FRANCE, [], true).setDebugMode(true),
+            new DummyBot(secondBotName, Countries.RUSSIA),
         ],
     };
 
@@ -93,6 +94,7 @@ async function main() {
     };
 
     const game = await cdapi.createGame(process.env.ONLINE_MATCH ? onlineSettings : offlineSettings1v1);
+
     while (!game.isFinished()) {
         if (!!MAX_GAME_LENGTH_SECONDS && game.getCurrentTick() / 15 > MAX_GAME_LENGTH_SECONDS) {
             console.log(`Game forced to end due to timeout`);
@@ -100,6 +102,9 @@ async function main() {
         }
         await game.update();
     }
+
+    console.log("done");
+    while (true) {}
 
     game.saveReplay();
     game.dispose();

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,13 +35,13 @@ async function main() {
     heckcorners_b_golden.map,hecklvl.map,heckrvr.map,hecktvt.map,isleland.map,jungleofvietnam.map,2_malibu_cliffs_le.map,mojosprt.map,4_montana_dmz_le.map,6_near_ore_far.map,8_near_ore_far.map,
     offensedefense.map,ore2_startfixed.map,rekoool_fast_6players.mpr,rekoool_fast_8players.mpr,riverram.map,tourofegypt.map,unrepent.map,sinkswim_yr_port.map
     */
-    const mapName = "heckcorners_b.map";
+    const mapName = "rekoool_fast_8players.mpr";
     // Bot names must be unique in online mode
     const timestamp = String(Date.now()).substr(-6);
-    const firstBotName = `Joe${timestamp}`;
-    const secondBotName = `Bob${timestamp}`;
-    const thirdBotName = `Mike${timestamp}`;
-    const fourthBotName = `Charlie${timestamp}`;
+    const botName1 = `Joe${timestamp}`;
+    const botName2 = `Bob${timestamp}`;
+    const botName3 = `Mike${timestamp}`;
+    const botName4 = `Charlie${timestamp}`;
 
     await cdapi.init(process.env.MIX_DIR || "./");
 
@@ -67,8 +67,8 @@ async function main() {
         serverUrl: process.env.SERVER_URL!,
         clientUrl: process.env.CLIENT_URL!,
         agents: [
-            new SupalosaBot(process.env.ONLINE_BOT_NAME ?? firstBotName, Countries.USA),
-            { name: process.env.PLAYER_NAME ?? secondBotName, country: Countries.FRANCE },
+            new SupalosaBot(process.env.ONLINE_BOT_NAME ?? botName1, Countries.USA),
+            { name: process.env.PLAYER_NAME ?? botName2, country: Countries.FRANCE },
         ] as [Bot, ...Agent[]],
         botPassword: process.env.ONLINE_BOT_PASSWORD ?? "default",
     };
@@ -77,8 +77,8 @@ async function main() {
         ...baseSettings,
         online: false,
         agents: [
-            new SupalosaBot(firstBotName, Countries.FRANCE, [], true).setDebugMode(true),
-            new SupalosaBot(secondBotName, Countries.FRANCE, [], false),
+            new SupalosaBot(botName1, Countries.FRANCE, [], true).setDebugMode(true),
+            new SupalosaBot(botName2, Countries.FRANCE, [], false),
         ],
     };
 
@@ -86,14 +86,35 @@ async function main() {
         ...baseSettings,
         online: false,
         agents: [
-            new SupalosaBot(firstBotName, Countries.FRANCE, [secondBotName], false),
-            new SupalosaBot(secondBotName, Countries.RUSSIA, [firstBotName], true).setDebugMode(true),
-            new SupalosaBot(thirdBotName, Countries.RUSSIA, [fourthBotName], false),
-            new SupalosaBot(fourthBotName, Countries.FRANCE, [thirdBotName], false),
+            new SupalosaBot(botName1, Countries.FRANCE, [botName2], false),
+            new SupalosaBot(botName2, Countries.RUSSIA, [botName1], true).setDebugMode(true),
+            new SupalosaBot(botName3, Countries.RUSSIA, [botName4], false),
+            new SupalosaBot(botName4, Countries.FRANCE, [botName3], false),
         ],
     };
 
-    const game = await cdapi.createGame(process.env.ONLINE_MATCH ? onlineSettings : offlineSettings2v2);
+    const botName5 = `Phil${timestamp}`;
+    const botName6 = `Sam${timestamp}`;
+    const botName7 = `Ben${timestamp}`;
+    const botName8 = `Jim${timestamp}`;
+    const team1 = [botName1, botName2, botName3, botName4];
+    const team2 = [botName5, botName6, botName7, botName8];
+    const offlineSettings4v4: CreateOfflineOpts = {
+        ...baseSettings,
+        online: false,
+        agents: [
+            new SupalosaBot(botName1, Countries.FRANCE, team1, false),
+            new SupalosaBot(botName2, Countries.RUSSIA, team1, true).setDebugMode(true),
+            new SupalosaBot(botName3, Countries.RUSSIA, team1, false),
+            new SupalosaBot(botName4, Countries.FRANCE, team1, false),
+            new SupalosaBot(botName5, Countries.FRANCE, team2, false),
+            new SupalosaBot(botName6, Countries.RUSSIA, team2, false),
+            new SupalosaBot(botName7, Countries.RUSSIA, team2, false),
+            new SupalosaBot(botName8, Countries.FRANCE, team2, false),
+        ],
+    };
+
+    const game = await cdapi.createGame(process.env.ONLINE_MATCH ? onlineSettings : offlineSettings4v4);
 
     console.profile(`cpuprofile-${timestamp}`);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,7 +78,7 @@ async function main() {
         online: false,
         agents: [
             new SupalosaBot(firstBotName, Countries.FRANCE, [], true).setDebugMode(true),
-            new DummyBot(secondBotName, Countries.RUSSIA),
+            new SupalosaBot(secondBotName, Countries.FRANCE, [], false),
         ],
     };
 
@@ -95,6 +95,8 @@ async function main() {
 
     const game = await cdapi.createGame(process.env.ONLINE_MATCH ? onlineSettings : offlineSettings1v1);
 
+    console.profile(`cpuprofile-${timestamp}`);
+
     while (!game.isFinished()) {
         if (!!MAX_GAME_LENGTH_SECONDS && game.getCurrentTick() / 15 > MAX_GAME_LENGTH_SECONDS) {
             console.log(`Game forced to end due to timeout`);
@@ -103,11 +105,9 @@ async function main() {
         await game.update();
     }
 
-    console.log("done");
-    while (true) {}
-
     game.saveReplay();
     game.dispose();
+    console.profileEnd();
 }
 
 main().catch((e) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,14 +86,14 @@ async function main() {
         ...baseSettings,
         online: false,
         agents: [
-            new SupalosaBot(firstBotName, Countries.FRANCE, [firstBotName], false),
+            new SupalosaBot(firstBotName, Countries.FRANCE, [secondBotName], false),
             new SupalosaBot(secondBotName, Countries.RUSSIA, [firstBotName], true).setDebugMode(true),
             new SupalosaBot(thirdBotName, Countries.RUSSIA, [fourthBotName], false),
             new SupalosaBot(fourthBotName, Countries.FRANCE, [thirdBotName], false),
         ],
     };
 
-    const game = await cdapi.createGame(process.env.ONLINE_MATCH ? onlineSettings : offlineSettings1v1);
+    const game = await cdapi.createGame(process.env.ONLINE_MATCH ? onlineSettings : offlineSettings2v2);
 
     console.profile(`cpuprofile-${timestamp}`);
 


### PR DESCRIPTION
`getUnitData` was (and still is) the most expensive call in short (~30 min) games.
In many cases, we can remove the call by using getGameObjectData. This is not 1:1, for example we compromise on units like IFVs and assume that they are always using the default weapon. That'll probably cause it to consider an IFV with a GI inside it as an anti-air unit, but worth the compromise for now.

Before:
![image](https://github.com/Supalosa/supalosa-chronodivide-bot/assets/1549353/7dedf5f9-16f3-4ffa-ab17-d3e16230b89b)

After:
![image](https://github.com/Supalosa/supalosa-chronodivide-bot/assets/1549353/f8aadcc6-bf2e-4a91-901e-cc8e3be45c74)

